### PR TITLE
【ページ構成】ワイヤーフレームの通りに各ページのコンポーネントを実装する 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,18 +2,10 @@
 import * as React from 'react';
 import { StylesProvider } from '@material-ui/styles';
 
-// import ShowIdeaContainer from './containers/showIdea/index';
-// import IdeaCreateAndEditContainer from './containers/createAndEditIdea/index'
-// import FbShareButton from './components/fbShareButton';
-// import TwShareButton from './components/twShareButton';
-// import HeaderContainer from './containers/headerContainer';
-// import FooterComponent from './components/footer'
-// import IdeaSingleComponent from './components/ideaSingleComponent';
-// import LatestIdeaComponent from './containers/topPageComponent/latestIdeaContainer';
-// import GoodCountIdeaComponent from './containers/topPageComponent/goodCountIdeaComponent'
-// import EditUserProfile from './containers/editUserProfileContainer';
-// import UserMyPage from './containers/myPage/index';
-import TopIndexComponent from './containers/topPageComponent/index'
+import UserMyPage from './containers/myPage';
+import TopIndexComponent from './containers/topPageComponent';
+import ShowIdeaContainer from './containers/showIdea';
+import IdeaCreateAndEditContainer from './containers/createAndEditIdea';
 
 
 
@@ -22,7 +14,7 @@ const App: React.FC = () => {
   return (
     <>
      <StylesProvider injectFirst>
-       <TopIndexComponent />
+       <UserMyPage />
      </StylesProvider>
     </>
   )

--- a/src/actions/commentAction.ts
+++ b/src/actions/commentAction.ts
@@ -22,7 +22,7 @@ export const getCommentById = {
     type: ActionTypes.GET_COMMENT_START as typeof ActionTypes.GET_COMMENT_START
   }),
 
-  success: (payload: Models.Comment) => ({
+  success: (payload: Models.Comment[]) => ({
     type: ActionTypes.GET_COMMENT_SUCCESS as typeof ActionTypes.GET_COMMENT_SUCCESS,
     payload: payload
   }),

--- a/src/apis/commentAPI.ts
+++ b/src/apis/commentAPI.ts
@@ -42,3 +42,31 @@ export const getCommentbyId = async (id: string) => {
     return { error };
   }
 }
+
+export const getAllComment = async () => {
+  try {
+    const comments: Models.Comment[] = [];
+    await firebase
+    .firestore()
+    .collection('comments')
+    .get()
+    .then(snapShot => {
+      if(snapShot.empty) {
+        console.log('comment dose not exist');
+        return;
+      }
+      snapShot.forEach(com => {
+        comments.push({
+          content: com.data().content ? com.data().content : 'no content',
+          userName: com.data().userName ? com.data().userName: 'no author',
+          createdAt: com.data().createdAt ? com.data().createdAt.toDate() : null
+        });
+      });
+    }).catch(error => {
+      throw new Error(error.message);
+    })
+    return { comments };
+  } catch(error) {
+    return { error };
+  }
+}

--- a/src/components/ideaSingleComponent.tsx
+++ b/src/components/ideaSingleComponent.tsx
@@ -8,6 +8,7 @@ import {
   characterLimit
  } from '../utils/utilFunctions';
 
+//  TODO: divタグで作成しているが呼び出ししている親コンポーネントで囲っている要素がpタグなのでコンソールにエラーが出ている。elemet要素を変更してエラーが出ないようにする
 const IdeaBox = styled.div`
   height: 250px;
 `;

--- a/src/containers/createAndEditIdea/index.tsx
+++ b/src/containers/createAndEditIdea/index.tsx
@@ -2,6 +2,8 @@ import React, { FC } from 'react';
 import styled from 'styled-components';
 
 import PostIdeaContainer from './ideaPostContainer';
+import HeaderContainer from '../headerContainer';
+import FooterComponent from '../../components/footer';
 
 const IdeaCreateAndEditWarapper = styled.div`
   width: 60%
@@ -11,10 +13,14 @@ const IdeaCreateAndEditWarapper = styled.div`
 
 const IdeaCreateAndEditContainer: FC = () => {
   return (
-    <IdeaCreateAndEditWarapper>
-      <PostIdeaContainer />
-    </IdeaCreateAndEditWarapper>
+    <>
+      <HeaderContainer />
+      <IdeaCreateAndEditWarapper>
+        <PostIdeaContainer />
+      </IdeaCreateAndEditWarapper>
+      <FooterComponent />
+    </>
   );
 };
 
-export default IdeaCreateAndEditContainer
+export default IdeaCreateAndEditContainer;

--- a/src/containers/editUserProfileContainer.tsx
+++ b/src/containers/editUserProfileContainer.tsx
@@ -14,7 +14,8 @@ import {
  } from '../actions/userAction';
 import { AppState } from '../models';
 import HeaderContainer from './headerContainer';
-import { Input } from '@material-ui/core';
+import FooterComponent from '../components/footer';
+
 
 const SubmitButton = styled(Button)`
   background: linear-gradient(45deg, #fe6b8b 30%, #ff8e53 90%);
@@ -128,7 +129,7 @@ const EditUserProfile: FC<DefaultProps> = ({
           <div>Login Please</div>
         )
       }
-
+      <FooterComponent />
     </>
   );
 };

--- a/src/containers/myPage/index.tsx
+++ b/src/containers/myPage/index.tsx
@@ -6,7 +6,9 @@ import Tab from '@material-ui/core/Tab';
 
 import UserMyPageDraftedIdeas from './userMyPageDrafedIdeaComponent';
 import UserMyPagePostedIdeas from './userMyPagePostedIdeaComponent';
-import IdeaShowUserProfile from '../showIdea/showIdeaUserProfile'
+import IdeaShowUserProfile from '../showIdea/showIdeaUserProfile';
+import HeaderContainer from '../headerContainer';
+import FooterComponent from '../../components/footer';
 import * as Styles from '../../utils/style';
 
 interface StateProps {
@@ -32,6 +34,7 @@ const UserMyPage: FC<DefaultProps> = ({
 
   return (
     <>
+      <HeaderContainer />
       <IdeaShowUserProfile />
       <div className={Styles.useStyles().root}>
         <AppBar position="static">
@@ -51,6 +54,7 @@ const UserMyPage: FC<DefaultProps> = ({
           Item Three
         </Styles.TabPanel>
       </div>
+      <FooterComponent />
     </>
   )
 }

--- a/src/containers/myPage/userMyPageDrafedIdeaComponent.tsx
+++ b/src/containers/myPage/userMyPageDrafedIdeaComponent.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import * as Models from '../../models/ideaModel';
 import { AppState } from '../../models';
 import { getIdeasUserDrafted } from '../../actions/ideaAction';
+import IdeaSingleComponent from '../../components/ideaSingleComponent';
 
 interface DispatchProps {
   getIdeasUserDrafted: (uid: string) => void;
@@ -13,14 +14,14 @@ interface DispatchProps {
 
 interface StateProps {
   isLoading: boolean;
-  draftedIdea: Models.PostIdea[];
+  draftedIdeas: Models.PostIdea[];
 }
 
 type DefaultProps = DispatchProps & StateProps;
 
 const UserMyPageDraftedIdeas: FC<DefaultProps> = ({
   isLoading,
-  draftedIdea,
+  draftedIdeas,
   getIdeasUserDrafted
 }) => {
 
@@ -31,14 +32,26 @@ const UserMyPageDraftedIdeas: FC<DefaultProps> = ({
   // 取得した投稿データを```IdeaSingleComponent```に渡して繰り返し表示させればOK
   return (
     <>
-      {console.log('UserMyPageDraftedIdeas', draftedIdea)}
+      { draftedIdeas ? (
+        <>
+          { draftedIdeas.map((idea) => {
+            return (
+              <IdeaSingleComponent idea={idea} key={idea.content.length} />
+            )
+          })}
+        </>
+      ) : (
+        <>
+          <p>No posts yet.</p>
+        </>
+      )}
     </>
   )
 };
 
 const mapStateToProps = (state: AppState) => ({
   isLoading: state.postIdea.isLoading,
-  draftedIdea: state.postIdea.postIdeas
+  draftedIdeas: state.postIdea.userDraftedIdeas
 })
 
 const mapDispatchToProps = (dispatch: Dispatch) =>

--- a/src/containers/myPage/userMyPagePostedIdeaComponent.tsx
+++ b/src/containers/myPage/userMyPagePostedIdeaComponent.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import * as Models from '../../models/ideaModel';
 import { AppState } from '../../models';
 import { getIdeasUserPosted } from '../../actions/ideaAction';
+import IdeaSingleComponent from '../../components/ideaSingleComponent';
 
 interface DispatchProps {
   getIdeasUserPosted: (uid: string) => void;
@@ -13,14 +14,14 @@ interface DispatchProps {
 
 interface StateProps {
   isLoading: boolean;
-  postedIdea: Models.PostIdea[];
+  postedIdeas: Models.PostIdea[];
 }
 
 type DefaultProps = DispatchProps & StateProps;
 
 const UserMyPagePostedIdeas: FC<DefaultProps> = ({
   isLoading,
-  postedIdea,
+  postedIdeas,
   getIdeasUserPosted
 }) => {
 
@@ -31,14 +32,27 @@ const UserMyPagePostedIdeas: FC<DefaultProps> = ({
   // 取得した投稿データを```IdeaSingleComponent```に渡して繰り返し表示させればOK
   return (
     <>
-      {console.log('UserMyPagePostedIdeas', postedIdea)}
+     { postedIdeas ? (
+        <>
+          { postedIdeas.map((idea) => {
+              return (
+                <IdeaSingleComponent idea={idea} key={idea.content.length} />
+              )})
+          }
+        </>
+      ) : (
+        <>
+          <p>No posts yet.</p>
+        </>
+      ) 
+      }
     </>
   )
 };
 
 const mapStateToProps = (state: AppState) => ({
   isLoading: state.postIdea.isLoading,
-  postedIdea: state.postIdea.postIdeas
+  postedIdeas: state.postIdea.userPostedIdeas
 })
 
 const mapDispatchToProps = (dispatch: Dispatch) =>

--- a/src/containers/showIdea/index.tsx
+++ b/src/containers/showIdea/index.tsx
@@ -6,6 +6,8 @@ import ShowIdeabyIdContainer from './showIdeaContainer';
 import IdeaShowUserProfile from './showIdeaUserProfile';
 import ShowCommentContainer from './showCommentContainer';
 import CreateCommentContainer from './createCommentContainer';
+import HeaderContainer from '../headerContainer';
+import FooterComponent from '../../components/footer';
 
 const ShowPageWarpper = styled.div`
   width: 50%
@@ -14,12 +16,16 @@ const ShowPageWarpper = styled.div`
 
 const ShowIdeaContainer: FC = () => {
   return (
-    <ShowPageWarpper>
-      <IdeaShowUserProfile />
-      <ShowIdeabyIdContainer />
-      <ShowCommentContainer />
-      <CreateCommentContainer />
-    </ShowPageWarpper>
+    <>
+      <HeaderContainer />
+      <ShowPageWarpper>
+        <IdeaShowUserProfile />
+        <ShowIdeabyIdContainer />
+        <ShowCommentContainer />
+        <CreateCommentContainer />
+      </ShowPageWarpper>
+      <FooterComponent />
+    </>
   );
 };
 

--- a/src/containers/showIdea/showCommentContainer.tsx
+++ b/src/containers/showIdea/showCommentContainer.tsx
@@ -25,7 +25,7 @@ const IdeaContent = styled.div`
 `
 
 interface Props {
-  comment: Models.Comment;
+  comments: Models.Comment[];
 };
 
 interface DispatchProps {
@@ -40,7 +40,7 @@ type DefaultProps = Props & DispatchProps & StateProps;
 
 const ShowCommentContainer: FC<DefaultProps> = ({
   isLoading,
-  comment,
+  comments,
   getCommentById
 }) => {
 
@@ -48,20 +48,24 @@ const ShowCommentContainer: FC<DefaultProps> = ({
     getCommentById()
   }, []);
 
-
-
   return (
     <>
-      { comment ? (
-        <IdeaContent>
-          <div style={{marginRight: '30px'}}>
-            <h5>{ comment.userName }</h5>
-          </div>
-          <div>
-            <h5>{ comment.content }</h5>
-            <h6>{CREATED_AT + ' ' + dateToString(comment.createdAt) }</h6>
-          </div>
-        </IdeaContent>
+      { comments ? (
+        <>
+          { comments.map(comment => {
+            return (
+              <IdeaContent>
+                <div style={{marginRight: '30px'}}>
+                  <h5>{ comment.userName }</h5>
+                </div>
+                <div>
+                  <h5>{ comment.content }</h5>
+                  <h6>{CREATED_AT + ' ' + dateToString(comment.createdAt) }</h6>
+                </div>
+              </IdeaContent>
+            )
+          })}
+        </>
       ): (<IdeaContent>{NOT_FOUND_IDEA}</IdeaContent>)}
     </>
   );
@@ -69,7 +73,7 @@ const ShowCommentContainer: FC<DefaultProps> = ({
 
 const mapStateToProps = (state: AppState) => ({
   isLoading: state.comment.isLoading,
-  comment: state.comment.comment
+  comments: state.comment.comments
 });
 
 const mapDispatchToProps = (dispatch: Dispatch) =>

--- a/src/models/commentModel.ts
+++ b/src/models/commentModel.ts
@@ -36,7 +36,7 @@ export interface GetCommentStart {
 
 export interface GetCommentSuccess {
   type: typeof ActionTypes.GET_COMMENT_SUCCESS,
-  payload: Comment
+  payload: Comment[]
 }
 
 export interface GetCommentFailure {

--- a/src/models/ideaModel.ts
+++ b/src/models/ideaModel.ts
@@ -17,7 +17,8 @@ export interface PostIdeaState {
   postIdea: PostIdea;
   postIdeas: PostIdea[];
   postIdeasbyLatest: PostIdea[];
-  draftedIdeas: PostIdea[];
+  userDraftedIdeas: PostIdea[];
+  userPostedIdeas: PostIdea[];
   ideasByGoodCount: PostIdea[];
 };
 

--- a/src/reducers/commentReducer.ts
+++ b/src/reducers/commentReducer.ts
@@ -45,7 +45,7 @@ const comment: Reducer<
         return {
           ...state,
           isLoading: false,
-          comment: action.payload
+          comments: action.payload
         }
       case ActionTypes.GET_COMMENT_FAILURE:
         return {

--- a/src/reducers/ideaReducer.ts
+++ b/src/reducers/ideaReducer.ts
@@ -14,7 +14,8 @@ const initialState: Models.PostIdeaState = {
   },
   postIdeas: [],
   postIdeasbyLatest: [],
-  draftedIdeas: [],
+  userDraftedIdeas: [],
+  userPostedIdeas: [],
   ideasByGoodCount: []
 }
 
@@ -124,7 +125,7 @@ const idea: Reducer<Models.PostIdeaState, Models.PostIdeaAction> = (
     case ActionTypes.GET_USER_POST_IDEA_SUCCESS:
       return {
         ...state,
-        postIdeas: action.payload,
+        userPostedIdeas: action.payload,
         isLoading: false
       }
     case ActionTypes.GET_USER_POST_IDEA_FAILURE:
@@ -140,7 +141,7 @@ const idea: Reducer<Models.PostIdeaState, Models.PostIdeaAction> = (
     case ActionTypes.GET_USER_DRAFT_IDEA_SUCCESS:
       return {
         ...state,
-        postIdeas: action.payload,
+        userDraftedIdeas: action.payload,
         isLoading: false
       }
     case ActionTypes.GET_USER_DRAFT_IDEA_FAILURE:

--- a/src/sagas/commentSaga.ts
+++ b/src/sagas/commentSaga.ts
@@ -23,13 +23,11 @@ export function* runCretaeComment(action: Models.CreateCommentStart) {
 
 // TODO: get comment by idea id
 export function* runGetCommentById() {
-  // mock id
-  const id = 'C8Al8oz9t3pgqoEx053r'
-  const handler = API.getCommentbyId;
-  const {comment, error} = yield call(handler, id);
-  if(comment && !error) {
+  const handler = API.getAllComment;
+  const {comments, error} = yield call(handler);
+  if(comments && !error) {
     console.log('OK commentSaga get');
-    yield put(getCommentById.success(comment));
+    yield put(getCommentById.success(comments));
   } else {
     console.log('NG commentSaga get');
     yield put(getCommentById.failure());


### PR DESCRIPTION
#52   
  
現在あるコンポーネントをつないで、ワイヤーフレーム通りのページを作成完了  
（検索機能に関してはいったん飛ばしているが、firestoreのデータ取得の際にwhereとか使えば行けそう、  
ユーザーの検索データをpayloadでAcitonに渡して渡ってきたデータをfirestoreで検索して、Storeに渡す？）