### PR TITLE
【ルーティング】ページごとにコンポーネントをまとめ、ルーティングを実装する

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,20 +1,29 @@
 // TODO: Component sepalete, According to the layout
 import * as React from 'react';
 import { StylesProvider } from '@material-ui/styles';
+import { 
+  BrowserRouter as Router, 
+  Route
+} from 'react-router-dom';
 
 import UserMyPage from './containers/myPage';
 import TopIndexComponent from './containers/topPageComponent';
 import ShowIdeaContainer from './containers/showIdea';
 import IdeaCreateAndEditContainer from './containers/createAndEditIdea';
-
-
+import HeaderContainer from './containers/headerContainer';
+import FooterComponent from './components/footer';
 
 
 const App: React.FC = () => {
   return (
     <>
      <StylesProvider injectFirst>
-       <UserMyPage />
+      <HeaderContainer />
+        <Router>
+          <Route exact path='/' component={TopIndexComponent} />
+          <Route path='/show/:ideaId' component={ShowIdeaContainer} />
+        </Router>
+      <FooterComponent />
      </StylesProvider>
     </>
   )

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,12 +18,14 @@ const App: React.FC = () => {
   return (
     <>
      <StylesProvider injectFirst>
-      <HeaderContainer />
         <Router>
-          <Route exact path='/' component={TopIndexComponent} />
-          <Route path='/show/:ideaId' component={ShowIdeaContainer} />
+          <HeaderContainer />
+            <Route exact path='/' component={TopIndexComponent} />
+            <Route path='/create' component={IdeaCreateAndEditContainer} />
+            <Route path='/show/:ideaId' component={ShowIdeaContainer} />
+            <Route path='/profile/:author_name' component={UserMyPage} />
+          <FooterComponent />
         </Router>
-      <FooterComponent />
      </StylesProvider>
     </>
   )

--- a/src/actions/ideaAction.ts
+++ b/src/actions/ideaAction.ts
@@ -30,8 +30,9 @@ export const draftIdeaAction =  {
 export const getIdeabyId = {
   // MUST TODO: start action need idea id, beacuse for show pages one idea specific.
   // dummy start action is not id now.
-  start: () => ({
-    type: ActionTypes.GET_IDEA_START as typeof ActionTypes.GET_IDEA_START
+  start: (ideaId: string) => ({
+    type: ActionTypes.GET_IDEA_START as typeof ActionTypes.GET_IDEA_START,
+    payload: ideaId
   }),
   // TODO: rename 'PostIdea', beacuse anywhere use 'PostIdea' interface
   success: (payload: Models.PostIdea) => ({

--- a/src/apis/ideaAPI.ts
+++ b/src/apis/ideaAPI.ts
@@ -158,6 +158,7 @@ export const getIdeasByGood = async () => {
       console.log('snapShot', snapShot)
       snapShot.forEach(doc => {
         ideas.push({
+          ideaId: doc.data().ideaId ? doc.data().ideaId : 404,
           title: doc.data().title ? doc.data().title : 'not title',
           content: doc.data().content,
           createdAt: doc.data().createdAt.toDate(),

--- a/src/apis/ideaAPI.ts
+++ b/src/apis/ideaAPI.ts
@@ -58,7 +58,7 @@ export const getIdeabyId = async (ideaId: string) => {
       }
       const data = Object.assign({}, doc.data());
       data.createdAt = data.createdAt.toDate();
-      data.updatedAt = data.updatedAt.toDate();
+      data.updatedAt = data.updatedAt ? data.updatedAt.toDate() : null;
       idea = data;
     }).catch(error => {
       console.log('Error getIdeaById firebase');
@@ -125,6 +125,7 @@ export const getIdeasByLatest = async () => {
       console.log('snapShot', snapShot)
       snapShot.forEach(doc => {
         ideas.push({
+          ideaId: doc.data().ideaId ? doc.data().ideaId : 404,
           title: doc.data().title ? doc.data().title : 'not title',
           content: doc.data().content,
           createdAt: doc.data().createdAt.toDate(),

--- a/src/apis/ideaAPI.ts
+++ b/src/apis/ideaAPI.ts
@@ -125,7 +125,7 @@ export const getIdeasByLatest = async () => {
       console.log('snapShot', snapShot)
       snapShot.forEach(doc => {
         ideas.push({
-          ideaId: doc.data().ideaId ? doc.data().ideaId : 404,
+          ideaId: doc.id,
           title: doc.data().title ? doc.data().title : 'not title',
           content: doc.data().content,
           createdAt: doc.data().createdAt.toDate(),
@@ -158,7 +158,7 @@ export const getIdeasByGood = async () => {
       console.log('snapShot', snapShot)
       snapShot.forEach(doc => {
         ideas.push({
-          ideaId: doc.data().ideaId ? doc.data().ideaId : 404,
+          ideaId: doc.id,
           title: doc.data().title ? doc.data().title : 'not title',
           content: doc.data().content,
           createdAt: doc.data().createdAt.toDate(),

--- a/src/components/LinkComponest.tsx
+++ b/src/components/LinkComponest.tsx
@@ -1,0 +1,19 @@
+import React, { FC, ReactElement } from "react";
+import styled from "styled-components";
+import { Link } from "react-router-dom";
+
+interface DefaultProps {
+  src: string;
+  children?: string | ReactElement<any>;
+}
+
+const LinkComponent: FC<DefaultProps> = ({
+  src,
+  children
+}) => {
+  return (
+    <Link to={src}>{children}</Link>
+  )
+};
+
+export default LinkComponent;

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,5 +1,11 @@
 import React, { FC } from 'react';
 import styled from 'styled-components';
+import { 
+  BrowserRouter as Router, 
+  Route
+} from 'react-router-dom';
+
+import LinkComponent from '../components/LinkComponest';
 
 const Footer = styled.footer`
   width: 100%;
@@ -24,21 +30,32 @@ const FooterMenu = styled.li`
 
 
 const FooterComponent: FC = () => {
+  const paths = ['administrator', 'privacy', 'terms', 'about', 'feedback']
   return (
     <>
-      
-      <Footer>
-        <ProductLogo>Product Logo</ProductLogo>
-        <FooterUl>
-          <FooterMenu><a href='#'>home ｜</a></FooterMenu>
-          <FooterMenu><a href='#'>運営者情報 ｜</a></FooterMenu>
-          <FooterMenu><a href='#'>利用規約 ｜</a></FooterMenu>
-          <FooterMenu><a href='#'>プライバシーポリシー ｜</a></FooterMenu>
-          <FooterMenu><a href='#'>お問い合わせ ｜</a></FooterMenu>
-          <FooterMenu><a href='#'>フィードバック</a></FooterMenu>
-        </FooterUl>
-        <p>© All rights reserved by shoichi kimita.</p>
-      </Footer>
+      <Router>
+        <Footer>
+          <ProductLogo>Product Logo</ProductLogo>
+          <FooterUl>
+            <FooterMenu>
+              <LinkComponent src={paths[0]}>home ｜</LinkComponent>
+            </FooterMenu>
+            <FooterMenu>
+              <LinkComponent src={paths[1]}>運営者情報 ｜</LinkComponent>
+            </FooterMenu>
+            <FooterMenu>
+              <LinkComponent src={paths[2]}>プライバシーポリシー ｜</LinkComponent>
+            </FooterMenu>
+            <FooterMenu>
+              <LinkComponent src={paths[3]}>お問い合わせ ｜</LinkComponent>
+            </FooterMenu>
+            <FooterMenu>
+              <LinkComponent src={paths[4]}>フィードバック ｜</LinkComponent>
+            </FooterMenu>
+          </FooterUl>
+          <p>© All rights reserved by shoichi kimita.</p>
+        </Footer>
+      </Router>
     </>
   );
 };

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,9 +1,5 @@
 import React, { FC } from 'react';
 import styled from 'styled-components';
-import { 
-  BrowserRouter as Router, 
-  Route
-} from 'react-router-dom';
 
 import LinkComponent from '../components/LinkComponest';
 
@@ -33,29 +29,27 @@ const FooterComponent: FC = () => {
   const paths = ['administrator', 'privacy', 'terms', 'about', 'feedback']
   return (
     <>
-      <Router>
-        <Footer>
-          <ProductLogo>Product Logo</ProductLogo>
-          <FooterUl>
-            <FooterMenu>
-              <LinkComponent src={paths[0]}>home ｜</LinkComponent>
-            </FooterMenu>
-            <FooterMenu>
-              <LinkComponent src={paths[1]}>運営者情報 ｜</LinkComponent>
-            </FooterMenu>
-            <FooterMenu>
-              <LinkComponent src={paths[2]}>プライバシーポリシー ｜</LinkComponent>
-            </FooterMenu>
-            <FooterMenu>
-              <LinkComponent src={paths[3]}>お問い合わせ ｜</LinkComponent>
-            </FooterMenu>
-            <FooterMenu>
-              <LinkComponent src={paths[4]}>フィードバック ｜</LinkComponent>
-            </FooterMenu>
-          </FooterUl>
-          <p>© All rights reserved by shoichi kimita.</p>
-        </Footer>
-      </Router>
+      <Footer>
+        <ProductLogo>Product Logo</ProductLogo>
+        <FooterUl>
+          <FooterMenu>
+            <LinkComponent src={paths[0]}>home ｜</LinkComponent>
+          </FooterMenu>
+          <FooterMenu>
+            <LinkComponent src={paths[1]}>運営者情報 ｜</LinkComponent>
+          </FooterMenu>
+          <FooterMenu>
+            <LinkComponent src={paths[2]}>プライバシーポリシー ｜</LinkComponent>
+          </FooterMenu>
+          <FooterMenu>
+            <LinkComponent src={paths[3]}>お問い合わせ ｜</LinkComponent>
+          </FooterMenu>
+          <FooterMenu>
+            <LinkComponent src={paths[4]}>フィードバック ｜</LinkComponent>
+          </FooterMenu>
+        </FooterUl>
+        <p>© All rights reserved by shoichi kimita.</p>
+      </Footer>
     </>
   );
 };

--- a/src/components/ideaSingleComponent.tsx
+++ b/src/components/ideaSingleComponent.tsx
@@ -23,20 +23,14 @@ interface StateProps {
 }
 
 const IdeaSingleComponent: FC<StateProps> = ({idea}) => {
-  let urlParams: string = '';
   if(!idea) return null;
-  if(idea.ideaId === 404){
-    urlParams = '404'
-  } else if (idea.ideaId !== 404 && idea.ideaId){
-    urlParams = idea.ideaId.toString()
-  }
 
   // ユーザーのプロフィールページでルーティングする時に今のままだと投稿詳細ページにうまく遷移しない
   // ユーザーのプロフィールページで投稿者名を出す必要もないのでそこも考える
   return (
     <>
       <IdeaBox>
-        <LinkComponent src={`show/${urlParams}`}>
+        <LinkComponent src={`show/${idea.ideaId}`}>
           <h3>{characterLimit(idea.content)}</h3>
         </LinkComponent>
         <DateBox>

--- a/src/components/ideaSingleComponent.tsx
+++ b/src/components/ideaSingleComponent.tsx
@@ -31,6 +31,8 @@ const IdeaSingleComponent: FC<StateProps> = ({idea}) => {
     urlParams = idea.ideaId.toString()
   }
 
+  // ユーザーのプロフィールページでルーティングする時に今のままだと投稿詳細ページにうまく遷移しない
+  // ユーザーのプロフィールページで投稿者名を出す必要もないのでそこも考える
   return (
     <>
       <IdeaBox>
@@ -38,7 +40,9 @@ const IdeaSingleComponent: FC<StateProps> = ({idea}) => {
           <h3>{characterLimit(idea.content)}</h3>
         </LinkComponent>
         <DateBox>
-          <h4>Author Name</h4>
+          <LinkComponent src={'/profile/author_name'}>
+            <h4>Author Name</h4>
+          </LinkComponent>
           <h4>{CREATED_AT} :</h4>
           <h4>{dateToString(idea.createdAt)}</h4>
         </DateBox>

--- a/src/components/ideaSingleComponent.tsx
+++ b/src/components/ideaSingleComponent.tsx
@@ -7,6 +7,7 @@ import {
   dateToString,
   characterLimit
  } from '../utils/utilFunctions';
+import LinkComponent from '../components/LinkComponest';
 
 //  TODO: divタグで作成しているが呼び出ししている親コンポーネントで囲っている要素がpタグなのでコンソールにエラーが出ている。elemet要素を変更してエラーが出ないようにする
 const IdeaBox = styled.div`
@@ -22,13 +23,20 @@ interface StateProps {
 }
 
 const IdeaSingleComponent: FC<StateProps> = ({idea}) => {
+  let urlParams: string = '';
   if(!idea) return null;
+  if(idea.ideaId === 404){
+    urlParams = '404'
+  } else if (idea.ideaId !== 404 && idea.ideaId){
+    urlParams = idea.ideaId.toString()
+  }
 
   return (
     <>
       <IdeaBox>
-        <h3>{idea.title ? characterLimit(idea.title): null}</h3>
-        <h3>{characterLimit(idea.content)}</h3>
+        <LinkComponent src={`show/${urlParams}`}>
+          <h3>{characterLimit(idea.content)}</h3>
+        </LinkComponent>
         <DateBox>
           <h4>Author Name</h4>
           <h4>{CREATED_AT} :</h4>

--- a/src/containers/createAndEditIdea/index.tsx
+++ b/src/containers/createAndEditIdea/index.tsx
@@ -2,8 +2,6 @@ import React, { FC } from 'react';
 import styled from 'styled-components';
 
 import PostIdeaContainer from './ideaPostContainer';
-import HeaderContainer from '../headerContainer';
-import FooterComponent from '../../components/footer';
 
 const IdeaCreateAndEditWarapper = styled.div`
   width: 60%
@@ -14,11 +12,9 @@ const IdeaCreateAndEditWarapper = styled.div`
 const IdeaCreateAndEditContainer: FC = () => {
   return (
     <>
-      <HeaderContainer />
       <IdeaCreateAndEditWarapper>
         <PostIdeaContainer />
       </IdeaCreateAndEditWarapper>
-      <FooterComponent />
     </>
   );
 };

--- a/src/containers/editUserProfileContainer.tsx
+++ b/src/containers/editUserProfileContainer.tsx
@@ -13,8 +13,6 @@ import {
   alreadyLoginUserAction,
  } from '../actions/userAction';
 import { AppState } from '../models';
-import HeaderContainer from './headerContainer';
-import FooterComponent from '../components/footer';
 
 
 const SubmitButton = styled(Button)`
@@ -86,7 +84,6 @@ const EditUserProfile: FC<DefaultProps> = ({
 
   return (
     <>
-      <HeaderContainer />
       { loginUser ? 
         (
           <TextFieldWapper>
@@ -129,7 +126,6 @@ const EditUserProfile: FC<DefaultProps> = ({
           <div>Login Please</div>
         )
       }
-      <FooterComponent />
     </>
   );
 };

--- a/src/containers/headerContainer.tsx
+++ b/src/containers/headerContainer.tsx
@@ -1,7 +1,11 @@
 import React, {FC, useEffect} from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
-import styed from 'styled-components';
+import styled from 'styled-components';
+import { 
+  BrowserRouter as Router, 
+  Route
+} from 'react-router-dom';
 
 // material ui
 import Button from '@material-ui/core/Button'
@@ -14,7 +18,8 @@ import {
   alreadyLoginUserAction
  } from '../actions/userAction';
 import { AppState } from '../models';
-import styled from 'styled-components';
+
+import LinkComponent from '../components/LinkComponest';
 
 const HeaderBox = styled.div`
   height: 50px;
@@ -22,19 +27,24 @@ const HeaderBox = styled.div`
   justify-content: center;
 `;
 
-const LoginInfo = styed.ul`
+const LoginInfo = styled.ul`
   list-style: none;
   display: flex;
 `;
 
-const LoginInfoNav = styed.li`
+const LoginInfoNav = styled.li`
   text-align: center;
   height: 50px;
   line-height: 50px;
   margin-right: 30px;
 `;
 
-const SessionButton = styed(Button)`
+const SessionButton = styled(Button)`
+  margin-left: auto;
+  margin-right: 200px;
+`;
+
+const CreateButton = styled(Button)`
   margin-left: auto;
   margin-right: 200px;
 `;
@@ -82,6 +92,11 @@ const HeaderContainer: FC<DefaultProps> = ({
               onClick={logoutUserAction}
               color="primary"
               variant="contained">Logout</SessionButton>
+            <LinkComponent src={'/create'}>
+              <SessionButton 
+                color="primary"
+                variant="contained">Create</SessionButton>
+            </LinkComponent>
           </LoginInfo>
         </HeaderBox>
       ) : (

--- a/src/containers/myPage/index.tsx
+++ b/src/containers/myPage/index.tsx
@@ -7,8 +7,6 @@ import Tab from '@material-ui/core/Tab';
 import UserMyPageDraftedIdeas from './userMyPageDrafedIdeaComponent';
 import UserMyPagePostedIdeas from './userMyPagePostedIdeaComponent';
 import IdeaShowUserProfile from '../showIdea/showIdeaUserProfile';
-import HeaderContainer from '../headerContainer';
-import FooterComponent from '../../components/footer';
 import * as Styles from '../../utils/style';
 
 interface StateProps {
@@ -34,7 +32,6 @@ const UserMyPage: FC<DefaultProps> = ({
 
   return (
     <>
-      <HeaderContainer />
       <IdeaShowUserProfile />
       <div className={Styles.useStyles().root}>
         <AppBar position="static">
@@ -54,7 +51,6 @@ const UserMyPage: FC<DefaultProps> = ({
           Item Three
         </Styles.TabPanel>
       </div>
-      <FooterComponent />
     </>
   )
 }

--- a/src/containers/showIdea/index.tsx
+++ b/src/containers/showIdea/index.tsx
@@ -6,25 +6,28 @@ import ShowIdeabyIdContainer from './showIdeaContainer';
 import IdeaShowUserProfile from './showIdeaUserProfile';
 import ShowCommentContainer from './showCommentContainer';
 import CreateCommentContainer from './createCommentContainer';
-import HeaderContainer from '../headerContainer';
-import FooterComponent from '../../components/footer';
+
 
 const ShowPageWarpper = styled.div`
   width: 50%
   margin: 0 auto;
 `
+// 投稿一覧画面から遷移した時に指定の投稿データの詳細を表示するために投稿に関するIDを全て取得しなければいけない
+interface StateProps {
+  ideaId: number;
+  ideaAuthorId: number;
+  ideaCommentId: number
+}
 
 const ShowIdeaContainer: FC = () => {
   return (
     <>
-      <HeaderContainer />
       <ShowPageWarpper>
         <IdeaShowUserProfile />
         <ShowIdeabyIdContainer />
         <ShowCommentContainer />
         <CreateCommentContainer />
       </ShowPageWarpper>
-      <FooterComponent />
     </>
   );
 };

--- a/src/containers/showIdea/showIdeaContainer.tsx
+++ b/src/containers/showIdea/showIdeaContainer.tsx
@@ -12,7 +12,10 @@ import {
   chagneGoodCount
  } from '../../actions/ideaAction';
 import { AppState } from '../../models';
-import { dateToString } from '../../utils/utilFunctions';
+import { 
+  dateToString,
+  getUrlId
+ } from '../../utils/utilFunctions';
 
 // texts
 import {
@@ -47,7 +50,7 @@ interface StateProps {
 
 interface DispatchProps {
   // under implemetns arg is none, but arg is ideaId when production.
-  getIdeabyId: () => void;
+  getIdeabyId: (ideaId: string) => void;
   chagneGoodCount: () => void;
 }
 
@@ -60,14 +63,15 @@ const ShowIdeabyIdContainer: FC<DefaultProps> = ({
   idea
 }) => {
 
+  // util methodでURLからPostIDを取得するものを定義する
   useEffect(() => {
-    getIdeabyId()
+    getIdeabyId(getUrlId())
   }, []);
 
   const handleOnGoodCount = async (e: FormEvent) => {
     e.preventDefault();
     await chagneGoodCount();
-    await getIdeabyId();
+    await getIdeabyId(getUrlId());
   }
 
   return (
@@ -94,7 +98,7 @@ const mapStateToProps = (state: AppState) => ({
 
 const mapDisoatchToProps = (dispatch: Dispatch) => 
   bindActionCreators({
-    getIdeabyId: () => getIdeabyId.start(),
+    getIdeabyId: (ideaId: string) => getIdeabyId.start(ideaId),
     chagneGoodCount: () => chagneGoodCount.start()
   }, dispatch)
 

--- a/src/containers/topPageComponent/index.tsx
+++ b/src/containers/topPageComponent/index.tsx
@@ -8,8 +8,6 @@ import Tab from '@material-ui/core/Tab';
 import GoodCountIdeaComponent from './goodCountIdeaComponent';
 import LatestIdeaComponent from './latestIdeaContainer';
 import IdeaShowUserProfile from '../showIdea/showIdeaUserProfile';
-import HeaderContainer from '../headerContainer';
-import FooterComponent from '../../components/footer';
 import * as Styles from '../../utils/style';
 
 //  ユーザーのログイン判定のために使用する？
@@ -18,7 +16,6 @@ interface StateProps {
 }
 
 const TopIndexComponent: FC = ({}) => {
-
   const [value, setValue] = useState<number>(0);
 
   const handleChange = (event: React.ChangeEvent<{}>, newValue: number) => {
@@ -27,7 +24,6 @@ const TopIndexComponent: FC = ({}) => {
 
   return (
     <>
-     <HeaderContainer />
      <IdeaShowUserProfile />
       <div className={Styles.useStyles().root}>
         <AppBar position="static">
@@ -47,7 +43,6 @@ const TopIndexComponent: FC = ({}) => {
           フォロー中のユーザーの投稿が表示される
         </Styles.TabPanel>
       </div>
-      <FooterComponent />
     </>
   );
 };

--- a/src/models/ideaModel.ts
+++ b/src/models/ideaModel.ts
@@ -1,6 +1,7 @@
 import * as ActionTypes from '../constants/actionTypes';
 
 export interface PostIdea {
+  ideaId?: number;
   title?: string;
   content: string;
   createdAt: Date;

--- a/src/models/ideaModel.ts
+++ b/src/models/ideaModel.ts
@@ -1,7 +1,7 @@
 import * as ActionTypes from '../constants/actionTypes';
 
 export interface PostIdea {
-  ideaId?: number;
+  ideaId?: string;
   title?: string;
   content: string;
   createdAt: Date;
@@ -66,6 +66,7 @@ export interface DraftIdeaFailure {
 //  GET IDEA BY ID
 export interface GetIdeaStart {
   type: typeof ActionTypes.GET_IDEA_START;
+  payload: string
 }
 
 export interface GetIdeaSuccess {

--- a/src/reducers/ideaReducer.ts
+++ b/src/reducers/ideaReducer.ts
@@ -6,7 +6,7 @@ import * as Models from '../models/ideaModel';
 const initialState: Models.PostIdeaState = {
   isLoading: false,
   postIdea: {
-    ideaId: 0,
+    ideaId: '',
     title: '',
     content: '',
     goodCount: 0,

--- a/src/reducers/ideaReducer.ts
+++ b/src/reducers/ideaReducer.ts
@@ -6,6 +6,7 @@ import * as Models from '../models/ideaModel';
 const initialState: Models.PostIdeaState = {
   isLoading: false,
   postIdea: {
+    ideaId: 0,
     title: '',
     content: '',
     goodCount: 0,

--- a/src/sagas/ideaSaga.ts
+++ b/src/sagas/ideaSaga.ts
@@ -42,7 +42,7 @@ export function* runDraftIdea(actions: Models.DraftIdeaStart) {
 // TODO: arg is change for idea id.
 // Temporary support Under development.
 export function* runGetIdeaById() {
-   const mockId = 'testGetIdeaById';
+   const mockId = 'sc8oMiX69PLux8FhGR5E';
    const handler = API.getIdeabyId;
    const {idea, error} = yield call(handler, mockId);
    if(idea && !error) {

--- a/src/sagas/ideaSaga.ts
+++ b/src/sagas/ideaSaga.ts
@@ -41,10 +41,10 @@ export function* runDraftIdea(actions: Models.DraftIdeaStart) {
 
 // TODO: arg is change for idea id.
 // Temporary support Under development.
-export function* runGetIdeaById() {
-   const mockId = 'sc8oMiX69PLux8FhGR5E';
+export function* runGetIdeaById(action: Models.GetIdeaStart) {
+   const ideaId = action.payload;
    const handler = API.getIdeabyId;
-   const {idea, error} = yield call(handler, mockId);
+   const {idea, error} = yield call(handler, ideaId);
    if(idea && !error) {
      console.log('runGetIdeaById OK');
      yield put(getIdeabyId.success(idea))

--- a/src/utils/utilFunctions.ts
+++ b/src/utils/utilFunctions.ts
@@ -10,3 +10,14 @@ export const characterLimit = (text: string) => {
   }
   return text;
 }
+
+// 現在のURL末尾の記事IDなどを取得
+export const getUrlId = (): string => {
+  const currentPath = window.location.pathname;
+  const result = currentPath.split("/");
+  if(result.length >= 3) {
+    return result[2];
+  } else {
+    return result[result.length - 1];
+  }
+};


### PR DESCRIPTION
#43   
  
投稿一覧表示画面から詳細画面へいくときのルーティングを作成  
FIrestoreからの全件取得の時に、docの自動生成されたIDをIdeaModelに持たせてそのIDで認識させルーテティングを作成している