### PR TITLE
【Firestore】投稿とユーザーデータの構造を変更

### DIFF
--- a/src/apis/ideaAPI.ts
+++ b/src/apis/ideaAPI.ts
@@ -6,7 +6,7 @@ export const postIdea = async (data: Models.PostIdea) => {
   try {
     await firebase
     .firestore()
-    .collection('Idea')
+    .collection('LinkedIdea')
     .doc()
     .set(data)
     .catch((error) => {
@@ -27,7 +27,7 @@ export const postDraftIdea = async (data: Models.PostIdea) => {
     console.log(data)
     await firebase
     .firestore()
-    .collection('DraftIdea')
+    .collection('LinkedDraftedIdea')
     .doc()
     .set(data)
     .catch((error) => {
@@ -116,16 +116,16 @@ export const getIdeasByLatest = async () => {
     await firebase
     .firestore()
     .collection('Idea')
-    .orderBy('updatedAt', 'desc')
     .get()
     .then(snapShot => {
       if(snapShot.empty){
         return;
       }
-      console.log('snapShot', snapShot)
       snapShot.forEach(doc => {
+        console.log('doc', doc.data());
         ideas.push({
           ideaId: doc.id,
+          uid: doc.id,
           title: doc.data().title ? doc.data().title : 'not title',
           content: doc.data().content,
           createdAt: doc.data().createdAt.toDate(),

--- a/src/models/ideaModel.ts
+++ b/src/models/ideaModel.ts
@@ -1,7 +1,9 @@
 import * as ActionTypes from '../constants/actionTypes';
 
+// オプショナルなプロパティはできるだけ無くしたい
 export interface PostIdea {
   ideaId?: string;
+  uid?: string;
   title?: string;
   content: string;
   createdAt: Date;

--- a/src/reducers/ideaReducer.ts
+++ b/src/reducers/ideaReducer.ts
@@ -7,6 +7,7 @@ const initialState: Models.PostIdeaState = {
   isLoading: false,
   postIdea: {
     ideaId: '',
+    uid: '',
     title: '',
     content: '',
     goodCount: 0,


### PR DESCRIPTION
#57   
  
DB構造を変更し、それにあわたせ投稿処理に修正  
  
## 投稿アイディア  
<img width="1135" alt="tuyano-angular-app_-_Cloud_Firestore_-_Firebase_コンソール" src="https://user-images.githubusercontent.com/48151772/94873272-b514c500-0489-11eb-9144-f2a876563352.png">
  
  
## 下書きアイディア  
<img width="1136" alt="tuyano-angular-app_-_Cloud_Firestore_-_Firebase_コンソール-2" src="https://user-images.githubusercontent.com/48151772/94873293-be9e2d00-0489-11eb-904b-f92cc9ae15f1.png">
