### PR TITLE
【ルーティング】特定のユーザープロフィールページへ遷移するように実装

### DIFF
--- a/src/apis/ideaAPI.ts
+++ b/src/apis/ideaAPI.ts
@@ -48,7 +48,7 @@ export const getIdeabyId = async (ideaId: string) => {
     let idea = null;
     await firebase
     .firestore()
-    .collection('Idea')
+    .collection('LinkedIdea')
     .doc(ideaId)
     .get()
     .then(doc => {
@@ -79,7 +79,7 @@ export const changeGoodCount = async (id: string) => {
     // いいね数を更新したい投稿の取得処理
     await firebase
     .firestore()
-    .collection('Idea')
+    .collection('LinkedIdea')
     .doc(id)
     .get()
     .then(doc => {
@@ -95,7 +95,7 @@ export const changeGoodCount = async (id: string) => {
     // いいね数の更新処理
     await firebase
     .firestore()
-    .collection('Idea')
+    .collection('LinkedIdea')
     .doc(id)
     .update({
       goodCount: currentCount ? currentCount + 1 : 666
@@ -115,7 +115,7 @@ export const getIdeasByLatest = async () => {
     const ideas: Models.PostIdea[] = [];
     await firebase
     .firestore()
-    .collection('Idea')
+    .collection('LinkedIdea')
     .get()
     .then(snapShot => {
       if(snapShot.empty){
@@ -125,7 +125,8 @@ export const getIdeasByLatest = async () => {
         console.log('doc', doc.data());
         ideas.push({
           ideaId: doc.id,
-          uid: doc.id,
+          uid: doc.data().uid ? doc.data().uid : 'empty',
+          authorName: doc.data().authorName ? doc.data().authorName : 'no author',
           title: doc.data().title ? doc.data().title : 'not title',
           content: doc.data().content,
           createdAt: doc.data().createdAt.toDate(),
@@ -148,7 +149,7 @@ export const getIdeasByGood = async () => {
     const ideas: Models.PostIdea[] = [];
     await firebase
     .firestore()
-    .collection('Idea')
+    .collection('LinkedIdea')
     .orderBy('goodCount', 'desc')
     .get()
     .then(snapShot => {
@@ -180,9 +181,8 @@ export const getUserPostedIdeas = async (uid: string) => {
     const postedIdeas: Models.PostIdea[] = [];
     await firebase
     .firestore()
-    .collection('Idea')
-    .doc('c62EgmuKdcBZB1md3Nvz')
-    .collection('postedIdea')
+    .collection('LinkedIdea')
+    .where('uid', '==', uid)
     .get()
     .then(doc => {
       if(doc.empty){

--- a/src/apis/ideaAPI.ts
+++ b/src/apis/ideaAPI.ts
@@ -211,9 +211,8 @@ export const getUserDraftedIdeas = async (uid: string) => {
     const draftedIdeas: Models.PostIdea[] = [];
     await firebase
     .firestore()
-    .collection('Idea')
-    .doc('c62EgmuKdcBZB1md3Nvz') // 本当はここにUIDを入れてユーザーごとのデータを取得できるようにする
-    .collection('draftedIdea')
+    .collection('LinkedDraftedIdea')
+    .where('uid', '==', uid)
     .get()
     .then(doc => {
       if(doc.empty){

--- a/src/components/ideaSingleComponent.tsx
+++ b/src/components/ideaSingleComponent.tsx
@@ -34,8 +34,8 @@ const IdeaSingleComponent: FC<StateProps> = ({idea}) => {
           <h3>{characterLimit(idea.content)}</h3>
         </LinkComponent>
         <DateBox>
-          <LinkComponent src={'/profile/author_name'}>
-            <h4>Author Name</h4>
+          <LinkComponent src={`/profile/${idea.uid}`}>
+            <h4>{ idea.authorName }</h4>
           </LinkComponent>
           <h4>{CREATED_AT} :</h4>
           <h4>{dateToString(idea.createdAt)}</h4>

--- a/src/containers/createAndEditIdea/ideaPostContainer.tsx
+++ b/src/containers/createAndEditIdea/ideaPostContainer.tsx
@@ -110,6 +110,7 @@ const PostIdeaContainer: FC<DefaultProps> = ({
     e.preventDefault();
     const payload = {
       uid: userInfo.userId,
+      authorName: userInfo.userName,
       title: title,
       content: ideaContent,
       goodCount: 0,

--- a/src/containers/myPage/userMyPageDrafedIdeaComponent.tsx
+++ b/src/containers/myPage/userMyPageDrafedIdeaComponent.tsx
@@ -7,6 +7,7 @@ import * as Models from '../../models/ideaModel';
 import { AppState } from '../../models';
 import { getIdeasUserDrafted } from '../../actions/ideaAction';
 import IdeaSingleComponent from '../../components/ideaSingleComponent';
+import { getUrlId } from '../../utils/utilFunctions';
 
 interface DispatchProps {
   getIdeasUserDrafted: (uid: string) => void;
@@ -26,7 +27,7 @@ const UserMyPageDraftedIdeas: FC<DefaultProps> = ({
 }) => {
 
   useEffect(() => {
-    getIdeasUserDrafted('c62EgmuKdcBZB1md3Nvz')
+    getIdeasUserDrafted(getUrlId())
   }, [])
 
   // 取得した投稿データを```IdeaSingleComponent```に渡して繰り返し表示させればOK

--- a/src/containers/myPage/userMyPagePostedIdeaComponent.tsx
+++ b/src/containers/myPage/userMyPagePostedIdeaComponent.tsx
@@ -7,6 +7,7 @@ import * as Models from '../../models/ideaModel';
 import { AppState } from '../../models';
 import { getIdeasUserPosted } from '../../actions/ideaAction';
 import IdeaSingleComponent from '../../components/ideaSingleComponent';
+import { getUrlId } from '../../utils/utilFunctions';
 
 interface DispatchProps {
   getIdeasUserPosted: (uid: string) => void;
@@ -26,7 +27,7 @@ const UserMyPagePostedIdeas: FC<DefaultProps> = ({
 }) => {
 
   useEffect(() => {
-    getIdeasUserPosted('c62EgmuKdcBZB1md3Nvz')
+    getIdeasUserPosted(getUrlId())
   }, [])
 
   // 取得した投稿データを```IdeaSingleComponent```に渡して繰り返し表示させればOK

--- a/src/models/ideaModel.ts
+++ b/src/models/ideaModel.ts
@@ -5,6 +5,7 @@ export interface PostIdea {
   ideaId?: string;
   uid?: string;
   title?: string;
+  authorName?: string;
   content: string;
   createdAt: Date;
   updatedAt: Date | null;

--- a/src/reducers/ideaReducer.ts
+++ b/src/reducers/ideaReducer.ts
@@ -8,6 +8,7 @@ const initialState: Models.PostIdeaState = {
   postIdea: {
     ideaId: '',
     uid: '',
+    authorName: '',
     title: '',
     content: '',
     goodCount: 0,


### PR DESCRIPTION
#56   
  
## 下書きアイディアでも同じ挙動になるように修正する  

・アイディアデータに投稿者名を追加  
・一覧で表示されるのはアイディアデータの中の投稿者名  
・投稿者名にアイディアデータの中のuidをulrのパラメータとして使用  
  
test  
・ダミーデータでuidが異なるものを２つ作成  
・一覧表示画面で投稿者名をクリック  
・それぞれのプロフィールページへ遷移することを確認  
・そのユーザーが投稿したデータしか表示されていないことを確認 