### PR TITLE
【ヘッダーコンポーネント】ユーザー情報の取得元をStateに変更する 

### DIFF
--- a/src/actions/userAction.ts
+++ b/src/actions/userAction.ts
@@ -2,9 +2,9 @@ import * as ActionTypes from '../constants/actionTypes';
 import * as Models from '../models/userModels';
 
 export const getUserInformation = {
-  // TODO: add paylod => uid: fireabase auth uid; beacuse, this action user after login.
-  start: () => ({
-    type: ActionTypes.GET_USER_PROFILE_START as typeof ActionTypes.GET_USER_PROFILE_START
+  start: (uid: string) => ({
+    type: ActionTypes.GET_USER_PROFILE_START as typeof ActionTypes.GET_USER_PROFILE_START,
+    payload: uid
   }),
 
   success: (userInfromation: Models.LoginUser) => ({

--- a/src/apis/userAPI.ts
+++ b/src/apis/userAPI.ts
@@ -99,7 +99,8 @@ export const firstUserSignUp = async(data: Models.LoginUser) => {
 
 export const loginCheck = async () => {
   try {
-    let loginUser = null;
+    let uid: string = '';
+    let userInfo = null;
     await firebase
     .auth()
     .onAuthStateChanged(user => {
@@ -107,10 +108,26 @@ export const loginCheck = async () => {
         return;
       }
       const data = Object.assign({}, setUserInfo(user));
-      loginUser = data;
-      console.log(loginUser, 'login check user');
+      uid = data.userId;
+      console.log(data.userId, 'login check user');
     })
-    return { loginUser };
+    
+    if(uid){
+      console.log(uid)
+      await firebase
+      .firestore()
+      .collection('users')
+      .doc(uid)
+      .get()
+      .then(doc => {
+        if(!doc){
+          return;
+        }
+        const uData = Object.assign({}, doc.data());
+        userInfo = uData
+      })
+    }
+    return { userInfo }
   } catch(error) {
     return { error };
   }

--- a/src/containers/headerContainer.tsx
+++ b/src/containers/headerContainer.tsx
@@ -15,10 +15,10 @@ import * as Models from '../models/userModels';
 import { 
   loginUserAction,
   logoutUserAction,
-  alreadyLoginUserAction
+  alreadyLoginUserAction,
+  getUserInformation
  } from '../actions/userAction';
 import { AppState } from '../models';
-
 import LinkComponent from '../components/LinkComponest';
 
 const HeaderBox = styled.div`
@@ -61,6 +61,7 @@ interface DispatchProps {
   loginUserAction: () => void;
   logoutUserAction: () => void;
   alreadyLogin: () => void;
+  getloginUserInfo: (uid: string) => void;
 }
 
 type DefaultProps = StateProps & DispatchProps & Props;
@@ -70,12 +71,19 @@ const HeaderContainer: FC<DefaultProps> = ({
   userInfo,
   loginUserAction,
   logoutUserAction,
-  alreadyLogin
+  alreadyLogin,
+  getloginUserInfo
 }) => {
   
   useEffect(() => {
     alreadyLogin()
+    getloginUserInfo(userInfo.userId);
+    console.log(userInfo.userId);
   }, []);
+
+  if(userInfo){
+    console.log(userInfo.userId ? userInfo.userId : 'nothing user id');
+  }
 
   return (
     <>
@@ -123,7 +131,8 @@ const mapDispatchToProps = (dispatch: Dispatch) =>
   bindActionCreators({
     loginUserAction: () => loginUserAction.start(),
     logoutUserAction: () => logoutUserAction.start(),
-    alreadyLogin: () => alreadyLoginUserAction.start()
+    alreadyLogin: () => alreadyLoginUserAction.start(),
+    getloginUserInfo: uid => getUserInformation.start(uid)
   }, dispatch)
 
 export default connect(

--- a/src/containers/showIdea/showIdeaUserProfile.tsx
+++ b/src/containers/showIdea/showIdeaUserProfile.tsx
@@ -6,9 +6,7 @@ import styled from 'styled-components';
 // material ui
 
 // file
-import {
-  getUserInformation
-} from '../../actions/userAction';
+import { getUserInformation } from '../../actions/userAction';
 import * as Models from '../../models/userModels';
 import { AppState } from '../../models';
 
@@ -22,8 +20,7 @@ interface Props {
 }
 
 interface DispatchProps {
-  // TODO: use login uid
-  getUserInfromation: () => void;
+  getUserInfromation: (uid: string) => void;
 }
 
 interface StateProps {
@@ -37,8 +34,11 @@ const IdeaShowUserProfile: FC<DefaultProps> = ({
   userInfromation,
   getUserInfromation
 }) => {
+
   useEffect(() => {
-    getUserInfromation()
+    if(userInfromation){
+      getUserInfromation(userInfromation.userId)
+    }
   }, [])
 
   return (
@@ -64,7 +64,7 @@ const mapStateToProps = (state: AppState) => ({
 
 const mapDispatchToState = (dispatch: Dispatch) => 
   bindActionCreators({
-    getUserInfromation: () => getUserInformation.start()
+    getUserInfromation: uid => getUserInformation.start(uid)
   }, dispatch);
 
 export default connect(

--- a/src/models/userModels.ts
+++ b/src/models/userModels.ts
@@ -17,7 +17,8 @@ export interface LoginUserState {
 
 // get login user information
 export interface GetLoginUserStart {
-  type: typeof ActionTypes.GET_USER_PROFILE_START
+  type: typeof ActionTypes.GET_USER_PROFILE_START;
+  payload: string;
 };
 
 export interface GetLoginUserSuccess {

--- a/src/sagas/userSaga.ts
+++ b/src/sagas/userSaga.ts
@@ -10,15 +10,13 @@ import {
   loginUserAction,
   logoutUserAction,
   alreadyLoginUserAction,
-  editUserProfile
+  editUserProfile,
 } from '../actions/userAction';
 
-export function* runGetUserInfromation() {
-  // TODO: This function after Login, baceuse uid is trigger, get user information;
-  // this function must be change
-  const data = 'testUser' // mock uid
+export function* runGetUserInfromation(action: Models.GetLoginUserStart) {
+  const uid = action.payload
   const handler = API.getUserInfromation;
-  const { userInfromation, error } = yield call(handler, data);
+  const { userInfromation, error } = yield call(handler, uid);
   if(userInfromation && !error) {
     console.log('GET USERINFROMATION OK')
     yield put(getUserInformation.success(userInfromation))
@@ -42,10 +40,10 @@ export function* runLoginUser() {
 
 export function* runAlreadyLogin() {
   const handler = API.loginCheck;
-  const { loginUser, error } = yield call(handler);
-  if(loginUser && !error) {
+  const { userInfo, error } = yield call(handler);
+  if(userInfo && !error) {
     console.log('ALREADY LOGIN SAGA OK');
-    yield put(alreadyLoginUserAction.success(loginUser));
+    yield put(alreadyLoginUserAction.success(userInfo));
   } else {
     console.log('ALREADY LOGIN SAGA NG');
     yield put(alreadyLoginUserAction.failure());


### PR DESCRIPTION
#68   
 
正しいログインとログアウトで画面繊維をしている場合は問題なく表示されているが、  
怪しい挙動をするのは以下の場合  
  
・ブラウザバックした場合  
・URLを直接打ち込まれた場合  
  
localStrageにログイン情報をセットするか  
ヘッダーコンポーネントに新しいコンポーネントがレンダリングされるたびにユーザー情報の確認を行う処理を加えるか  
全てのコンポーネントにログインユーザーの情報を確認させる処理を追加するか  
  
一番いいのは  
・ユーザーログイン  
・Stateに情報保存  
・ログアウトするまでその情報を保持し続ける  
  
いったんこれでOKにして、スタイリングに入る  
流石に今のままでは見辛いのでテストもしづらいため