### PR TITLE
【TOPページ】いいね順でアイディアが取得できていない

### DIFF
--- a/src/apis/ideaAPI.ts
+++ b/src/apis/ideaAPI.ts
@@ -169,23 +169,23 @@ export const getIdeasByGood = async () => {
   try {
     console.log('idea good count')
     const ideas: Models.PostIdea[] = [];
+    let resultIdeas: Models.PostIdea[] = [];
     await firebase
     .firestore()
     .collection('AllIdea')
     .orderBy('goodCount', 'desc')
-    .where('postFlag', '==', true)
     .get()
     .then(snapShot => {
       if(snapShot.empty){
         return;
       }
-      snapShot.forEach(doc => {
+      snapShot.forEach((doc) => {
         ideas.push({
           ideaId: doc.id,
           title: doc.data().title ? doc.data().title : 'not title',
           content: doc.data().content,
           uid: doc.data().uid,
-          authorName: doc.data().uid,
+          authorName: doc.data().authorName ? doc.data().authorName : 'no author',
           postFlag: doc.data().postFlag,
           createdAt: doc.data().createdAt.toDate(),
           updatedAt: doc.data().updatedAt ? doc.data().updatedAt.toDate() : null,
@@ -195,7 +195,10 @@ export const getIdeasByGood = async () => {
     }).catch(error => {
       throw new Error(error.message);
     })
-    return { ideas };
+    resultIdeas = ideas.filter(postData => 
+      postData.postFlag === true
+    )
+    return { resultIdeas };
   } catch(error) {
     return { error };
   }

--- a/src/components/ideaSingleComponent.tsx
+++ b/src/components/ideaSingleComponent.tsx
@@ -28,7 +28,7 @@ const IdeaBox = styled(Card)`
 //  TODO: divタグで作成しているが呼び出ししている親コンポーネントで囲っている要素がpタグなのでコンソールにエラーが出ている。elemet要素を変更してエラーが出ないようにする
 
 interface StateProps {
-  idea?: Models.PostIdea
+  idea?: Models.PostIdea;
 }
 
 const IdeaSingleComponent: FC<StateProps> = ({idea}) => {

--- a/src/sagas/ideaSaga.ts
+++ b/src/sagas/ideaSaga.ts
@@ -70,10 +70,10 @@ export function* runGetIdeasByLatest() {
 
 export function* runGetIdeasByGood() {
   const handler = API.getIdeasByGood;
-  const {ideas, error} = yield call(handler);
-  if(ideas && !error) {
+  const {resultIdeas, error} = yield call(handler);
+  if(resultIdeas && !error) {
     console.log('OK GetGoodIdeas Saga');
-    yield put(getIdeasByGoodCount.success(ideas));
+    yield put(getIdeasByGoodCount.success(resultIdeas));
   } else {
     console.log('NG GetGoodIdeas Saga');
     yield put(getIdeasByGoodCount.failure());


### PR DESCRIPTION
#78   
  
firestoreからデータを取得するとき検索クエリが２つ以上使用するとインデックスを作成しないと使用できなさそう  
[インデックスの種類](https://firebase.google.com/docs/firestore/query-data/index-overview?hl=ja)  
[インデックス管理](https://firebase.google.com/docs/firestore/query-data/indexing?hl=ja)  
  
以上を参考にして今後は作成したい  
  
現状だと  
1. 投稿アイディアをいいね順で全て取得  
2. 取得したアイディアで本投稿フラグがtrueになっているものを新たな配列として作成し、Storeに更新  
  
コードでカバーしているがイケてないのでfirestore側で制御したい